### PR TITLE
Fix overlapping text display on Chapters

### DIFF
--- a/src/components/BookHome.js
+++ b/src/components/BookHome.js
@@ -10,7 +10,7 @@ class BookHome extends Component {
     return (
       <div className="UpGoing">
         <MuiThemeProvider>
-          <List style={{ width: "40%", margin: "0 auto", textAlign: "left" }}>
+          <List style={{ width: "40%", margin: "0 auto", textAlign: "center" }}>
             {book.chapters.map(chapter => (
               <Link
                 key={book.id+chapter.url}
@@ -18,7 +18,7 @@ class BookHome extends Component {
                 to={book.url + chapter.url}
               >
                 <ListItem
-                  style={{ fontSize: "30px" }}
+                  style={{ fontSize: "25px", lineHeight: "25px" }}
                   primaryText={chapter.title}
                 />
               </Link>


### PR DESCRIPTION
![](https://i.imgur.com/1kvKG2g.png)

Fixed by shrinking font size from 30px to 25px; add lineHeight of 25px;

Centered the text instead of left-align to make it look less awkward on mobile display 