### PR TITLE
Fix color change for answer submittal

### DIFF
--- a/src/__tests__/Question.js
+++ b/src/__tests__/Question.js
@@ -136,21 +136,21 @@ it('should set correct answer to green on submit', () => {
   });
 });
 
-it('should set incorrect answer to red and correct answer to green on submit', () => {
+it('should set incorrect answer to red', () => {
   const comp = shallow(<Question {...generateTestProps(upGoingCh1Q1)} />);
-  comp.instance().handleAnswerChange({ target: { value: 3 } });
+  comp.instance().handleAnswerChange({ target: { value: 2 } });
   comp.instance().handleSubmit({ preventDefault: () => {} });
   expect(comp.instance().state.error).toBe(false);
-  expect(comp.instance().state.userAnswerId).toBe(3);
+  expect(comp.instance().state.userAnswerId).toBe(2);
   expect(comp.instance().state.answerSubmitted).toBe(true);
   return Promise.resolve().then(() => {
     comp.update();
     expect(
       comp
         .find('span')
-        .at(3)
+        .at(2)
         .html()
-    ).toMatch(/color:green/);
+    ).toMatch(/color:red/);
   });
 });
 

--- a/src/components/Question.js
+++ b/src/components/Question.js
@@ -166,7 +166,10 @@ class Question extends Component {
               {question.answers.map((answer, i) => {
                 let answerColor;
                 if (answerSubmitted) {
-                  if (question.correctAnswerId === answer.id) {
+                  if (
+                    userAnswerId == answer.id &&
+                    (question.correctAnswerId === answer.id)
+                  ) {
                     answerColor = { color: 'green' };
                   }
                   if (


### PR DESCRIPTION
Submitting incorrect answer only changes incorrect answer's color to red.

Submitting correct answer changes the color to green.

Updated accompanying enzyme tests to go along with this.  