### PR TITLE
Added link to chapter section inside explanation

### DIFF
--- a/src/components/Question/Question.js
+++ b/src/components/Question/Question.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { withRouter, Link } from 'react-router-dom';
+import { withRouter } from 'react-router-dom';
 import {
   Fieldset,
   FlatButton,
@@ -43,7 +43,6 @@ class Question extends Component {
       error: false,
       correctAnswer: null,
       explanationRequested: false,
-      moreInfoUrl: null,
     };
   }
 

--- a/src/components/Question/Question.js
+++ b/src/components/Question/Question.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
+import { withRouter, Link } from 'react-router-dom';
 import {
   Fieldset,
   FlatButton,
@@ -43,6 +43,7 @@ class Question extends Component {
       error: false,
       correctAnswer: null,
       explanationRequested: false,
+      moreInfoUrl: null,
     };
   }
 
@@ -207,7 +208,17 @@ class Question extends Component {
                   >
                     Hide Explanation
                   </button>
-                  <div className="explanation">{question.explanation}</div>
+                  <div className="explanation">
+                    {question.explanation}
+                    <br />
+                    <a
+                      href={question.moreInfoUrl}
+                      target="_blank"
+                      style={{ textDecoration: 'underline', color: 'blue' }}
+                    >
+                      Github link to the chapter section
+                    </a>
+                  </div>
                 </div>
               )}
 

--- a/src/data/UpGoing/ch1.js
+++ b/src/data/UpGoing/ch1.js
@@ -158,7 +158,7 @@ const Ch1Questions = [
         id: 1,
       },
       {
-        text: 'var counter = 1 ;',
+        text: 'var counter += 1 ;',
         id: 2,
       },
       {


### PR DESCRIPTION
As discussed on issue https://github.com/austintackaberry/ydkjs-exercises/issues/90 
When testing, please note that some of the newer questions in Up&Going don't have a moreInfoUrl field yet; Will be added soon. 

Last minute addition: this includes a fix for https://github.com/austintackaberry/ydkjs-exercises/issues/101 (typo in Up&going chapter 01, question 7)