### PR TITLE
Allow keyboard navigation to previous/next question

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12539,9 +12539,9 @@
       }
     },
     "url-parse": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.1.tgz",
-      "integrity": "sha512-x95Td74QcvICAA0+qERaVkRpTGKyBHHYdwL2LXZm5t/gBtCB9KQSO/0zQgSTYEV1p0WcvSg79TLNPSvd5IDJMQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
       "requires": {
         "querystringify": "^2.0.0",
         "requires-port": "^1.0.0"

--- a/src/__tests__/Question.js
+++ b/src/__tests__/Question.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-
 import { score } from '../score-context';
-
-import Question from '../components/Question';
+import { Question } from '../components/Question';
 import books from '../data';
 
 const upGoingCh1Q1 = books[0].chapters[0].questions[0];

--- a/src/components/Question/Question.js
+++ b/src/components/Question/Question.js
@@ -43,14 +43,24 @@ class Question extends Component {
     score: PropTypes.object.isRequired,
     updateScore: PropTypes.func.isRequired,
   };
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       userAnswerId: null,
       answerSubmitted: null,
       error: false,
       correctAnswer: null,
       explanationRequested: false,
+      navigation: {
+        previous: {
+          enabled: this.props.index > 1,
+          url: this.props.baseUrl + '/q' + (this.props.index - 1),
+        },
+        next: {
+          enabled: this.props.index < this.props.numberOfQuestions,
+          url: this.props.baseUrl + '/q' + (this.props.index + 1),
+        },
+      },
     };
   }
 
@@ -109,26 +119,47 @@ class Question extends Component {
     });
   }
 
+  handleKeyDown(event) {
+    const ARROW_LEFT = 'ArrowLeft';
+    const ARROW_RIGHT = 'ArrowRight';
+    const { previous, next } = this.state.navigation;
+    switch (event.key) {
+      case ARROW_LEFT:
+        previous.enabled
+          ? this.props.history.push(previous.url)
+          : window.addEventListener('keydown', e => this.handleKeyDown(e), {
+              once: true,
+            });
+        break;
+      case ARROW_RIGHT:
+        next.enabled
+          ? this.props.history.push(next.url)
+          : window.addEventListener('keydown', e => this.handleKeyDown(e), {
+              once: true,
+            });
+        break;
+      default:
+        break;
+    }
+    event.preventDefault();
+  }
+
   toggleExplanationRequest() {
     this.setState({
       explanationRequested: !this.state.explanationRequested,
     });
   }
 
+  componentDidMount() {
+    window.addEventListener('keydown', e => this.handleKeyDown(e), {
+      once: true,
+    });
+  }
+
   render() {
     const { answerSubmitted, userAnswerId, explanationRequested } = this.state;
-    const { question, baseUrl, index, numberOfQuestions } = this.props;
-    const navigation = {
-      previous: {
-        enabled: index > 1,
-        url: baseUrl + '/q' + (index - 1),
-      },
-      next: {
-        enabled: index < numberOfQuestions,
-        url: baseUrl + '/q' + (index + 1),
-      },
-    };
-
+    const { question, numberOfQuestions, index } = this.props;
+    const navigation = this.state.navigation;
     let message;
     if (this.state.error) {
       message = 'Please select an answer';
@@ -269,4 +300,5 @@ class Question extends Component {
   }
 }
 
-export default Question;
+const QuestionWithRouter = withRouter(Question);
+export default QuestionWithRouter;

--- a/src/components/Question/Question.js
+++ b/src/components/Question/Question.js
@@ -130,20 +130,16 @@ export class Question extends Component {
     };
 
     /* handle navigation */
-    try {
+    if (actions.hasOwnProperty(event.key)) {
       const { route } = actions[event.key];
       if (route.enabled) {
         this.props.history.push(route.url);
         return;
       }
-    } catch (TypeError) {
-      /* if a key besides left/right arrow is pressed, carry on to next line */
     }
 
     /* re-register listener if navigation did not occur */
-    window.addEventListener('keydown', this.handleKeyDown, {
-      once: true,
-    });
+    window.addEventListener('keydown', this.handleKeyDown);
   }
 
   toggleExplanationRequest() {
@@ -158,9 +154,7 @@ export class Question extends Component {
      * have to re-register the listener if this.props.history.push() is not fired
      * see handleKeyDown()
      */
-    window.addEventListener('keydown', this.handleKeyDown, {
-      once: true,
-    });
+    window.addEventListener('keydown', this.handleKeyDown);
   }
   componentWillUnmount() {
     window.removeEventListener('keydown', this.handleKeyDown);

--- a/src/components/Question/Question.js
+++ b/src/components/Question/Question.js
@@ -32,7 +32,7 @@ const NavigationButton = props =>
     </FlatButton>
   ))(props);
 
-class Question extends Component {
+export class Question extends Component {
   static propTypes = {
     baseUrl: PropTypes.string.isRequired,
     bookId: PropTypes.number.isRequired,
@@ -120,28 +120,43 @@ class Question extends Component {
   }
 
   handleKeyDown(event) {
+    /* don't trigger navigation if the current url isn't a question */
+    const pathname = this.props.history.location.pathname;
+    if (!pathname.match(/\/ch\d\/q\d/)) return false;
+
+    /* assign navigation variables */
     const ARROW_LEFT = 'ArrowLeft';
     const ARROW_RIGHT = 'ArrowRight';
     const { previous, next } = this.state.navigation;
+
+    /* handle navigation */
     switch (event.key) {
       case ARROW_LEFT:
+        event.preventDefault();
         previous.enabled
           ? this.props.history.push(previous.url)
-          : window.addEventListener('keydown', e => this.handleKeyDown(e), {
-              once: true,
-            });
+          : window.addEventListener(
+              'keydown',
+              event => this.handleKeyDown(event),
+              { once: true }
+            );
         break;
       case ARROW_RIGHT:
+        event.preventDefault();
         next.enabled
           ? this.props.history.push(next.url)
-          : window.addEventListener('keydown', e => this.handleKeyDown(e), {
-              once: true,
-            });
+          : window.addEventListener(
+              'keydown',
+              event => this.handleKeyDown(event),
+              { once: true }
+            );
         break;
       default:
+        window.addEventListener('keydown', event => this.handleKeyDown(event), {
+          once: true,
+        });
         break;
     }
-    event.preventDefault();
   }
 
   toggleExplanationRequest() {
@@ -149,9 +164,14 @@ class Question extends Component {
       explanationRequested: !this.state.explanationRequested,
     });
   }
-
   componentDidMount() {
-    window.addEventListener('keydown', e => this.handleKeyDown(e), {
+    /**
+     * register a keydown listener on the window that propagates exactly once
+     * to prevent unnecessary key repeats
+     * have to re-register the listener if this.props.history.push() is not fired
+     * see handleKeyDown()
+     */
+    window.addEventListener('keydown', event => this.handleKeyDown(event), {
       once: true,
     });
   }

--- a/src/components/Question/Question.js
+++ b/src/components/Question/Question.js
@@ -175,6 +175,9 @@ export class Question extends Component {
       once: true,
     });
   }
+  componentWillUnmount() {
+    window.removeEventListener('keydown', event => this.handleKeyDown(event));
+  }
 
   render() {
     const { answerSubmitted, userAnswerId, explanationRequested } = this.state;

--- a/src/components/Question/Question.js
+++ b/src/components/Question/Question.js
@@ -148,12 +148,6 @@ export class Question extends Component {
     });
   }
   componentDidMount() {
-    /**
-     * register a keydown listener on the window that propagates exactly once
-     * to prevent unnecessary key repeats
-     * have to re-register the listener if this.props.history.push() is not fired
-     * see handleKeyDown()
-     */
     window.addEventListener('keydown', this.handleKeyDown);
   }
   componentWillUnmount() {

--- a/src/components/Question/Question.js
+++ b/src/components/Question/Question.js
@@ -62,6 +62,8 @@ export class Question extends Component {
         },
       },
     };
+
+    this.handleKeyDown = this.handleKeyDown.bind(this);
   }
 
   calcNewScore(isCorrect) {
@@ -120,43 +122,28 @@ export class Question extends Component {
   }
 
   handleKeyDown(event) {
-    /* don't trigger navigation if the current url isn't a question */
-    const pathname = this.props.history.location.pathname;
-    if (!pathname.match(/\/ch\d\/q\d/)) return false;
-
     /* assign navigation variables */
-    const ARROW_LEFT = 'ArrowLeft';
-    const ARROW_RIGHT = 'ArrowRight';
     const { previous, next } = this.state.navigation;
+    const actions = {
+      ArrowLeft: { route: previous },
+      ArrowRight: { route: next },
+    };
 
     /* handle navigation */
-    switch (event.key) {
-      case ARROW_LEFT:
-        event.preventDefault();
-        previous.enabled
-          ? this.props.history.push(previous.url)
-          : window.addEventListener(
-              'keydown',
-              event => this.handleKeyDown(event),
-              { once: true }
-            );
-        break;
-      case ARROW_RIGHT:
-        event.preventDefault();
-        next.enabled
-          ? this.props.history.push(next.url)
-          : window.addEventListener(
-              'keydown',
-              event => this.handleKeyDown(event),
-              { once: true }
-            );
-        break;
-      default:
-        window.addEventListener('keydown', event => this.handleKeyDown(event), {
-          once: true,
-        });
-        break;
+    try {
+      const { route } = actions[event.key];
+      if (route.enabled) {
+        this.props.history.push(route.url);
+        return;
+      }
+    } catch (TypeError) {
+      /* if a key besides left/right arrow is pressed, carry on to next line */
     }
+
+    /* re-register listener if navigation did not occur */
+    window.addEventListener('keydown', this.handleKeyDown, {
+      once: true,
+    });
   }
 
   toggleExplanationRequest() {
@@ -171,12 +158,12 @@ export class Question extends Component {
      * have to re-register the listener if this.props.history.push() is not fired
      * see handleKeyDown()
      */
-    window.addEventListener('keydown', event => this.handleKeyDown(event), {
+    window.addEventListener('keydown', this.handleKeyDown, {
       once: true,
     });
   }
   componentWillUnmount() {
-    window.removeEventListener('keydown', event => this.handleKeyDown(event));
+    window.removeEventListener('keydown', this.handleKeyDown);
   }
 
   render() {

--- a/src/components/Question/index.js
+++ b/src/components/Question/index.js
@@ -1,1 +1,1 @@
-export { default } from './Question';
+export { default, Question } from './Question';


### PR DESCRIPTION
#129 

**One note**: I decided to register the keyboard listener to the `window` rather than to a specific component in `Question`. The reason being that the actual `Question` component must be focused for keyboard events to register, and I figured that would be a pretty bad UX decision.

Changed the structure of `Question.js` quite a bit to accommodate. This is my first time directly working with React Router, so please chime in if there's a better way to do this. Thanks!