### PR TITLE
Added Reset Button Component to Sidebar

### DIFF
--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -1,8 +1,28 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { List, ListItem, ListItemTitle, Divider, Wrapper } from './styled';
-import { Link } from 'react-router-dom';
+import {
+  List,
+  ListItem,
+  ListItemTitle,
+  Divider,
+  Wrapper,
+  FlatButton,
+} from './styled';
+import { Link, withRouter } from 'react-router-dom';
 import ProgressBar from '../ProgressBar';
+
+const ResetButton = props =>
+  withRouter(({ history }) => (
+    <FlatButton
+      onClick={() => {
+        localStorage.clear();
+        history.push('/');
+        document.location.reload();
+      }}
+    >
+      Reset Progress
+    </FlatButton>
+  ))(props);
 
 class Sidebar extends Component {
   static propTypes = {
@@ -67,6 +87,9 @@ class Sidebar extends Component {
             </Link>
           ))}
         </List>
+        <section>
+          <ResetButton />
+        </section>
       </Wrapper>
     );
   }

--- a/src/components/Sidebar/styled.js
+++ b/src/components/Sidebar/styled.js
@@ -36,3 +36,10 @@ export const Wrapper = styled.div`
   height: 100%;
   z-index: 99999;
 `;
+
+export const FlatButton = styled.button`
+  background-color: lightgrey;
+  border: none;
+  padding: 0.5rem 1.5rem;
+`;
+FlatButton.displayName = 'FlatButton';


### PR DESCRIPTION
How's this implementation?
anything else I should add or remove?

const ResetButton = props =>
  withRouter(({ history }) => (
    <FlatButton
      onClick={() => {
        localStorage.clear();
        history.push('/');
        document.location.reload();
      }}
    >
      Reset Progress
    </FlatButton>
  ))(props);