### PR TITLE
Fix markdown issue in Up and Going Ch 2 Question 4

### DIFF
--- a/src/components/markdown-renderers/CodeBlock.js
+++ b/src/components/markdown-renderers/CodeBlock.js
@@ -19,7 +19,11 @@ export default class CodeBlock extends React.PureComponent {
     return (
       <SyntaxHighlighter
         style={tomorrowNightEighties}
-        customStyle={{ borderRadius: '2px', textAlign: 'left' }}
+        customStyle={{
+          borderRadius: '0.25em',
+          textAlign: 'left',
+          padding: '0.3em 0.3em calc(0.3em + 1px)',
+        }}
         language={language}
       >
         {value}

--- a/src/components/markdown-renderers/CodeInline.js
+++ b/src/components/markdown-renderers/CodeInline.js
@@ -21,8 +21,8 @@ export default class CodeInline extends React.PureComponent {
         style={tomorrowNightEighties}
         customStyle={{
           display: 'inline',
-          padding: '0.3em',
-          borderRadius: '1px',
+          padding: '0.3em 0.3em calc(0.3em + 1px)',
+          borderRadius: '0.15em',
         }}
         language={language}
       >

--- a/src/data/UpGoing/ch1.js
+++ b/src/data/UpGoing/ch1.js
@@ -353,7 +353,7 @@ const Ch1Questions = [
       },
       {
         text:
-          'The code: "if true { console.log("this is true!"); }" is writtent in valid syntax and will print out the string.',
+          'The code: "if true { console.log("this is true!"); }" is written in valid syntax and will print out the string.',
         id: 3,
       },
     ],

--- a/src/data/UpGoing/ch2.js
+++ b/src/data/UpGoing/ch2.js
@@ -51,7 +51,7 @@ const Ch2Questions = [
   },
   {
     question:
-      "What is the return value of: typeof [1,2,3] === typeof {val: 'a', val: 'b', val: 'c'}; ?",
+      "What is the return value of: typeof `[1,2,3] === typeof {val: 'a', val: 'b', val: 'c'};` ?",
     questionId: '6jXvxXQQTnwPLsSayrJS',
     shouldBeRandomized: false,
     answers: [
@@ -164,10 +164,10 @@ const Ch2Questions = [
     questionId: 'KVa9gyVWvT9ymLmIeeGm',
     shouldBeRandomized: false,
     answers: [
-      { text: 'var b = Number( "5" );', id: 0 },
-      { text: 'var b = "5" * 1;', id: 1 },
-      { text: 'var b= "Hello, world" * 1;', id: 2 },
-      { text: 'var b= String( 5 )', id: 3 },
+      { text: '`var b = Number( "5" );`', id: 0 },
+      { text: '`var b = "5" * 1;`', id: 1 },
+      { text: '`var b = "Hello, world" * 1;`', id: 2 },
+      { text: '`var b = String( 5 );`', id: 3 },
     ],
     correctAnswerId: 1,
     moreInfoUrl:
@@ -177,7 +177,7 @@ const Ch2Questions = [
   },
   {
     question:
-      'If var a = 42 and var b = "42", will the statements a === b AND a == b return ...?',
+      'If var a = 42 and var b = "42", what will the statements a === b AND a == b return?',
     questionId: 'w5G9jSN6Hj9UD4VcfsFV',
     shouldBeRandomized: false,
     answers: [
@@ -372,10 +372,10 @@ const Ch2Questions = [
     questionId: 'pdnSBOr7Cy4Q6TeZeOpI',
     shouldBeRandomized: false,
     answers: [
-      { text: '(function IIFE(){ console( "Hello!" ); })();', id: 0 },
-      { text: 'function IIFE(){ console.log( "Hello!" ); }();', id: 1 },
-      { text: 'function IIFE(){ console.log( "Hello!" ); }', id: 2 },
-      { text: '(function IIFE(){ console.log( "Hello!" ); })();', id: 3 },
+      { text: '`(function IIFE(){ console( "Hello!" ); })();`', id: 0 },
+      { text: '`function IIFE(){ console.log( "Hello!" ); }();`', id: 1 },
+      { text: '`function IIFE(){ console.log( "Hello!" ); }`', id: 2 },
+      { text: '`(function IIFE(){ console.log( "Hello!" ); })();`', id: 3 },
     ],
     correctAnswerId: 3,
     moreInfoUrl:


### PR DESCRIPTION
Hey, I found a question that was rendering incorrectly and leading to one of the answers being wrong.

When fixing this, I noticed the inline code blocks have really sharp edges, so I bumped the border-radius to `0.15em`, rather than `1px`.

I also wrapped some other text in Chapter 2 with backticks to render as code. I only did it where it made sense, as some questions read better without the syntax highlighting, IMO.

If there's anything you want me to roll back, let me know!

Question on current prod:

<img width="767" alt="screen shot 2018-08-19 at 9 57 10 am" src="https://user-images.githubusercontent.com/3639170/44310141-fbd0ff00-a396-11e8-8928-d88bc50b0b61.png">

Question after this PR:

<img width="881" alt="screen shot 2018-08-19 at 10 02 44 am" src="https://user-images.githubusercontent.com/3639170/44310146-0c817500-a397-11e8-8e98-7d0c78de2231.png">
