### PR TITLE
Fix ES6 & Beyond Chapter 5 Question 2

### DIFF
--- a/src/data/ES6Beyond/ch5.js
+++ b/src/data/ES6Beyond/ch5.js
@@ -44,7 +44,7 @@ ${'```'}
       },
       { text: 'False', id: 1 },
     ],
-    correctAnswerId: 0,
+    correctAnswerId: 1,
     moreInfoUrl:
       'https://github.com/getify/You-Dont-Know-JS/blob/master/es6%20%26%20beyond/ch5.md#maps',
     explanation:


### PR DESCRIPTION
As per the explanation, Maps cannot be accessed using `[]` and the answer is "False"