### PR TITLE
Fix formatting of ES6 & Beyond Chapter 6 Question 2 Explanation

### DIFF
--- a/src/data/ES6Beyond/ch6.js
+++ b/src/data/ES6Beyond/ch6.js
@@ -51,7 +51,7 @@ const Ch6Questions = [
     moreInfoUrl:
       'https://github.com/getify/You-Dont-Know-JS/blob/master/es6%20%26%20beyond/ch6.md#numberisnan-static-function',
     explanation:
-      "`isNan() checks for things that are not a number. So that includes `NaN` and any other value that isn't a number.",
+      "`isNaN()` checks for things that are not a number. So that includes `NaN` and any other value that isn't a number.",
   },
   {
     question: `What will be logged to the console when the following code is executed:


### PR DESCRIPTION
The explanation forgets a closing backtick on the first `isNaN` and also the capitalization is off.