### PR TITLE
Fix ES6 & Beyond Chapter 7 Question 4

### DIFF
--- a/src/data/ES6Beyond/ch7.js
+++ b/src/data/ES6Beyond/ch7.js
@@ -138,7 +138,7 @@ ${'```'}
         id: 3,
       },
     ],
-    correctAnswerId: 0,
+    correctAnswerId: 1,
     moreInfoUrl:
       'https://github.com/getify/You-Dont-Know-JS/blob/master/es6%20%26%20beyond/ch7.md#symboltostringtag-and-symbolhasinstance',
     explanation:


### PR DESCRIPTION
As per the explanation, `obj2.toString()` is `"[object foo]"` because `Symbol.toStringTag` only change the tag used in the default `toString` method, not the method itself.