### PR TITLE
Update FlatButton colors when not disabled

### DIFF
--- a/src/components/Question/styled.js
+++ b/src/components/Question/styled.js
@@ -71,7 +71,7 @@ export const QuestionStyle = styled.h4`
 QuestionStyle.displayName = 'QuestionStyle';
 
 export const FlatButton = styled.button`
-  background-color: lightgrey;
+  background-color: ${p => (p.disabled ? 'lightgrey' : 'lightgreen')};
   border: none;
   padding: 0.5rem 1.5rem;
   disabled: ${p => p.disabled};


### PR DESCRIPTION
I noticed that when using the app, it wasn't always clear when a button was disabled. Making it green makes it clear it's clickable when it's ready.

![ydkjs](https://user-images.githubusercontent.com/13424/44313792-318bdd00-a3c3-11e8-841e-c2ea229365d8.png)
