### PR TITLE
Adds no-console to eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/registerServiceWorker.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,16 @@
 {
-  "extends": ["react-app", "plugin:jsx-a11y/recommended"],
-  "plugins": ["jsx-a11y"],
+  "extends": [
+    "react-app",
+    "plugin:jsx-a11y/recommended"
+  ],
+  "plugins": [
+    "jsx-a11y"
+  ],
   "rules": {
     "eqeqeq": "off",
     "no-useless-escape": "off",
     "prefer-destructuring": "error",
-    "prefer-template": "error"
+    "prefer-template": "error",
+    "no-console": "warn"
   }
 }

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -84,7 +84,7 @@ module.exports = {
     // for React Native Web.
     extensions: ['.web.js', '.mjs', '.js', '.json', '.web.jsx', '.jsx'],
     alias: {
-      
+
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
@@ -115,7 +115,8 @@ module.exports = {
             options: {
               formatter: eslintFormatter,
               eslintPath: require.resolve('eslint'),
-              
+              emitWarning: true
+
             },
             loader: require.resolve('eslint-loader'),
           },
@@ -144,7 +145,7 @@ module.exports = {
             include: paths.appSrc,
             loader: require.resolve('babel-loader'),
             options: {
-              
+
               // This is a feature of `babel-loader` for webpack (not Babel itself).
               // It enables caching results in ./node_modules/.cache/babel-loader/
               // directory for faster rebuilds.


### PR DESCRIPTION
I also updated the Webpack dev config to allow the application still build if console statements are added rather than just crash entirely. 

Relates to https://github.com/austintackaberry/ydkjs-exercises/issues/123