### PR TITLE
Fix mobile experience

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,7 +19,7 @@ const books = initializeBooks(rawBooks);
 const AppGrid = styled.div`
   display: grid;
   grid-template-columns: auto 1fr auto;
-  grid-template-rows: minmax(15vh, min-content) 1fr minmax(15vh, min-content);
+  grid-template-rows: minmax(10vh, min-content) 1fr minmax(15vh, min-content);
   grid-template-areas:
     'sidebar header'
     'sidebar main'
@@ -53,7 +53,7 @@ const MainContentGridChild = styled.div`
   place-self: start stretch;
   text-align: center;
   transition: var(--easing-standard);
-  width: 100%;
+  min-width: 100%;
 `;
 
 class App extends Component {

--- a/src/components/BookRouter.js
+++ b/src/components/BookRouter.js
@@ -17,8 +17,8 @@ class BookRouter extends Component {
         <Link style={{ textDecoration: 'none', color: 'black' }} to={book.url}>
           <h2
             style={{
-              fontSize: '35px',
-              margin: '10px 0',
+              fontSize: '1.8rem',
+              margin: '0 0 10px',
               textDecoration: 'underline',
             }}
           >

--- a/src/components/ChapterRouter.js
+++ b/src/components/ChapterRouter.js
@@ -53,7 +53,9 @@ class ChapterRouter extends Component {
 
     return (
       <div>
-        <h3 style={{ fontSize: '24px' }}>{chapter.title}</h3>
+        <h3 style={{ fontSize: '24px', margin: '12.5px auto 22.5px' }}>
+          {chapter.title}
+        </h3>
         <Switch>
           <Route
             exact

--- a/src/components/Footer/styled.js
+++ b/src/components/Footer/styled.js
@@ -5,4 +5,5 @@ export const FooterGridChild = styled.div`
   place-self: center stretch;
   font-style: italic;
   text-align: center;
+  padding: 10px;
 `;

--- a/src/components/Header/styled.js
+++ b/src/components/Header/styled.js
@@ -3,11 +3,11 @@ import styled from 'styled-components';
 export const HeaderGridChild = styled.div`
   grid-area: header;
   padding: 0.5rem;
-  place-self: center stretch;
+  place-self: flex-end stretch;
   text-align: center;
 `;
 
 export const Marquee = styled.span`
-  font-size: 3rem;
+  font-size: 2rem;
   font-weight: bolder;
 `;

--- a/src/components/Question/Question.js
+++ b/src/components/Question/Question.js
@@ -189,10 +189,11 @@ export class Question extends Component {
                         alignItems: 'center',
                         justifyContent: 'flex-start',
                         padding: '3px 0',
+                        maxWidth: '100%',
                       }}
                       htmlFor={i}
                     >
-                      <div style={{ height: '13px' }}>
+                      <div>
                         <input
                           type="radio"
                           name={index}

--- a/src/components/Question/styled.js
+++ b/src/components/Question/styled.js
@@ -12,6 +12,7 @@ export const Wrapper = styled.div`
   padding: 20px 10px;
   form {
     line-height: 2;
+    overflow-x: auto;
   }
 `;
 Wrapper.displayName = 'Wrapper';
@@ -46,7 +47,7 @@ export const Fieldset = styled.fieldset`
   text-align: left;
   border: none;
   div {
-    margin: 7px;
+    margin: 5px 7px 0;
   }
 `;
 Fieldset.displayName = 'Fieldset';


### PR DESCRIPTION
Fixes:
- reduced the sizing issue for the page title, book title and chapter title
- the radio buttons for answer selection are now centre-aligned
- The answer-section now overflows with scrollbar, so longer answer-options don't get cut off

Relates to #143 