### PR TITLE
`var counter += 1;` was a valid answer

### DIFF
--- a/src/data/UpGoing/ch1.js
+++ b/src/data/UpGoing/ch1.js
@@ -166,7 +166,7 @@ const Ch1Questions = [
         id: 1,
       },
       {
-        text: '`var counter += 1;`',
+        text: '`var newCounter = oldCounter + 1;`',
         id: 2,
       },
       {


### PR DESCRIPTION
Unless I'm missing something (it is Monday morning so hey) `var counter += 1;`  contains "one literal value, one variable, and one operator" as per the question. The "addition assignment" is one operator, even though it's logically short for two other operators: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Assignment_Operators#Addition_assignment_2