### PR TITLE
Fix mobile styling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,7 +26,7 @@ const AppGrid = styled.div`
     'sidebar footer';
   grid-row-gap: 0.5rem;
   height: 100%;
-  overflow-x: hidden;
+  overflow-x: scroll;
   overflow-y: ${props =>
     props.shouldShowSidebar && props.isNarrowScreen ? 'hidden' : 'scroll'};
   z-index: 0;

--- a/src/components/Footer/styled.js
+++ b/src/components/Footer/styled.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 export const FooterGridChild = styled.div`
   grid-area: footer;
   place-self: center stretch;
+  padding: 0 15px;
   font-style: italic;
   text-align: center;
 `;

--- a/src/components/Question/Question.js
+++ b/src/components/Question/Question.js
@@ -192,14 +192,13 @@ export class Question extends Component {
                       }}
                       htmlFor={i}
                     >
-                      <div style={{ height: '13px' }}>
+                      <div>
                         <input
                           type="radio"
                           name={index}
                           id={i}
                           value={answer.id}
                           data-testid={`answer-${answer.id}`}
-                          style={{ marginTop: '0' }}
                           onChange={event => {
                             this.handleAnswerChange(event);
                           }}


### PR DESCRIPTION
- Add `overflow-x: scroll` to allow users to scroll and see cut-off content
- Add padding to footer
- Vertically-align answer radio buttons

![mobile-styling](https://user-images.githubusercontent.com/5217136/58225534-4c370d80-7cd7-11e9-95f1-eb3acaec90b4.gif)

Reference to #143
(title sizes are also mentioned in that issue but it looks like the main page title font size has already been decreased so I'm not sure if that's still a problem)