### PR TITLE
Add text wrapping to code snippets

### DIFF
--- a/src/components/markdown-renderers/CodeInline.js
+++ b/src/components/markdown-renderers/CodeInline.js
@@ -23,6 +23,7 @@ export default class CodeInline extends React.PureComponent {
           display: 'inline',
           padding: '0.3em 0.3em calc(0.3em + 1px)',
           borderRadius: '0.15em',
+          whiteSpace: 'pre-wrap',
         }}
         language={language}
       >


### PR DESCRIPTION
This was added to improve the mobile experience and prevent the need for horizontal scrolling. A good place to see this in action is in the book "Up & Going" Ch.1, question 9.

#232